### PR TITLE
Example of the Linter 

### DIFF
--- a/pipline1.yaml
+++ b/pipline1.yaml
@@ -1,0 +1,63 @@
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  labels:
+    app.kubernetes.io/version: "0.1"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.12.1"
+    tekton.dev/tags: "appstudio, hacbs"
+  name: apply-tags
+spec:
+  description: >-
+    Applies additional tags to the built image.
+  params:
+  - name: IMAGE
+    description: Reference of image that was pushed to registry in the buildah task.
+    type: string
+  - name: ADDITIONAL_TAGS
+    description: Additional tags that will be applied to the image in the registry.
+    type: array
+    default: []
+  steps:
+    - name: apply-additional-tags-from-parameter
+      image: registry.access.redhat.com/ubi9/skopeo:9.4-6@sha256:c4d70dec3eb0a0c831490192145ea25431fe04d1cf307f8d61e2d87adb41e7e3
+      args:
+        - $(params.ADDITIONAL_TAGS[*])
+      env:
+      - name: IMAGE
+        value: $(params.IMAGE)
+      script: |
+        #!/bin/bash
+
+        if [ "$#" -ne 0 ]; then
+          IMAGE_WITHOUT_TAG=$(echo "$IMAGE" | sed 's/:[^:]*$//')
+          for tag in "$@"; do
+            echo "Applying tag $tag"
+            skopeo copy docker://$IMAGE docker://$IMAGE_WITHOUT_TAG:$tag
+          done
+        else
+          echo "No additional tags parameter specified"
+        fi
+
+    - name: apply-additional-tags-from-image-label
+      image: registry.access.redhat.com/ubi9/skopeo:9.4-6@sha256:c4d70dec3eb0a0c831490192145ea25431fe04d1cf307f8d61e2d87adb41e7e3
+      env:
+      - name: IMAGE
+        value: $(params.IMAGE)
+      script: |
+        #!/bin/bash
+
+        ADDITIONAL_TAGS_FROM_IMAGE_LABEL=$(skopeo inspect --format '{{ index .Labels "konflux.additional-tags" }}' docker://$IMAGE)
+
+        if [ -n "${ADDITIONAL_TAGS_FROM_IMAGE_LABEL}" ]; then
+          IFS=', ' read -r -a tags_array <<< "$ADDITIONAL_TAGS_FROM_IMAGE_LABEL"
+
+          IMAGE_WITHOUT_TAG=$(echo "$IMAGE" | sed 's/:[^:]*$//')
+          for tag in "${tags_array[@]}"
+          do
+              echo "Applying tag $tag"
+              skopeo copy docker://$IMAGE docker://$IMAGE_WITHOUT_TAG:$tag
+          done
+        else
+          echo "No additional tags specified in the image labels"
+        fi


### PR DESCRIPTION
When you open a PR, Checkton runs to check for any linting issues. Even if there are linting problems, the tests will pass because Checkton is configured with `fail-on-findings: false`. Instead, it outputs the warnings, and then we upload the results to SARIF. This allows the PR to provide warnings and suggestions without blocking the merge.

**Example:**
_For example, in `pipline1.yaml`, there are linting problems. Checkton finds these issues but does not fail the workflow. Instead, we upload the result to SARIF, which will create warning messages, as seen below ._

